### PR TITLE
Captcha 시간 초과시 발생하는 오류 수정 및 OTP

### DIFF
--- a/cleaner.js
+++ b/cleaner.js
@@ -29,6 +29,7 @@ async function start(id, pw) {
             await browser.close();
         }
     });
+    await page.setDefaultNavigationTimeout(0)
     await page.goto('https://www.dcinside.com/');
     await page.type("#user_id", id)
     await page.type("#pw", pw)


### PR DESCRIPTION
시간 제한을 없애버려서 캡챠에 실패했을 경우 다시 클리너를 실행 시켜야 하는 문제를 해결합니다.
OTP 를 사용하는 유저를 위해 로그인 대기 시간을 추가 했습니다.